### PR TITLE
Bug in a seneca-mail dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ node_modules
 test/sendconf.mine.js
 test/mine.js
 
+.idea/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "underscore": "~1.6.0",
-    "email-templates": "~0.1.1",
+    "email-templates": "~1.1.0",
     "nodemailer": "~0.7.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Email-templates have fixed a bug described here:
https://github.com/niftylettuce/node-email-templates/pull/60
which is causing problems with the use of seneca-mail.
