### PR TITLE
Update email-templates version since `.jade > .pug` actualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Richard Rodger (http://richardrodger.com)",
   "license": "MIT",
   "dependencies": {
-    "email-templates": "~2.0.1",
+    "email-templates": "~2.3.0",
     "eraro": "^0.4.1",
     "lab": "^6.2.0",
     "nodemailer": "~1.4.0",


### PR DESCRIPTION
Since `consolidate 0.14.1` has been merged, and in the process of compiling template with the new engine motor `.pug` (ex `.jade`). The plugin required latest version of the `email-template` module proposed in this PR.
